### PR TITLE
feat: adds theme infra + themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,56 @@ Edit `src/data/communities.yml` and add an entry:
 
 Community accounts are also used to fetch events — any `community.lexicon.calendar.event` records on the account's PDS will automatically appear on the Events page and homepage.
 
+## Contributing a theme
+
+The site supports multiple visual themes — pick one with the toggle in the header. Each theme is a single CSS file under `src/styles/themes/`. Adding one is a 3-touchpoint job.
+
+### How theming is layered
+
+1. **Base tokens** (e.g. `--color-primary`, `--color-base-100`) — plain colors. **Themes redefine these.**
+2. **Semantic tokens** (e.g. `--foreground`, `--card`, `--success-muted`) — composed from base. Components consume these. Theme-agnostic.
+3. **Component tokens** (e.g. `--header-bg`, `--card-radius`, `--btn-primary-shadow`) — scoped knobs. Default to a semantic value; **themes may override** for theme-specific patterns.
+
+Themes MUST NOT touch the semantic layer or the structural tokens (spacing, type scale, breakpoints, motion durations). They MAY override fonts (`--font-display`, `--font-body`) — many themes hinge on type.
+
+### Steps
+
+1. **Copy the template.**
+   ```sh
+   cp src/styles/themes/_template.css src/styles/themes/<your-theme>.css
+   ```
+   Replace every `REPLACE_ME` with your theme id (lowercase, no spaces — e.g. `seafoam`, `vapor-95`).
+
+2. **Fill in the base tokens.** All of them, with plain colors. Every `*-content` token must hit ≥4.5:1 contrast on its paired surface (or 3:1 for large/UI text on badges).
+
+3. **Override component tokens as needed.** The template lists every available knob, commented out — uncomment what you change, delete the rest. Common starting points: `--header-bg`, `--card-shadow`, `--hero-bg`.
+
+4. **Register the theme.** Two one-liners:
+   - Add `@import "./themes/<your-theme>.css";` to `src/styles/tokens.base.css`
+   - Add an entry to the `themes` array in `src/lib/themes.ts`:
+     ```ts
+     { id: '<your-theme>', name: '<Display Name>', scheme: 'light' | 'dark' }
+     ```
+
+5. **Test it.** `npm run dev`, cycle to your theme via the header toggle, click around every page. Verify card hovers, button states, badges, the hero, and the mobile hamburger.
+
+### Theme rules (cheat sheet)
+
+- **Specificity:** theme blocks use `:root[data-theme="<name>"]` — that beats the `:root` defaults in the semantic and component layers regardless of import order.
+- **Dark themes:** invert the surface ramp — `--color-base-100` is the *darkest* (page bg), and elevation lifts toward lighter shades. Lower chroma than the light equivalent.
+- **Reduced motion:** if your theme animates anything, wrap the motion overrides in `@media (prefers-reduced-motion: reduce)` to disable them.
+- **Skip link:** if you set `position: relative` on `body > *` for a layered background, exclude `.skip-link` so it stays offscreen until focused.
+- **Lexicon-ready:** keep base tokens as plain colors (no `color-mix`, no `var()` chains). The base layer is intended to be serializable into a `community.atmosphere.theme` lexicon record someday.
+
+### Existing themes
+
+| Id | Mood |
+|---|---|
+| `horizon` | Default light — warm, breezy, blues and corals |
+| `blacksky` | Deep indigo dark mode |
+| `ngerakines` | Y2K / GeoCities — Comic Sans, ridge borders, flashing buttons |
+| `fujocoded` | Lavender→blush gradient, glass navbar, signature 3D buttons |
+
 ## Data sources
 
 | Data | Source | Fetched at |

--- a/src/components/CommunityCard.astro
+++ b/src/components/CommunityCard.astro
@@ -53,9 +53,9 @@ function handleColor(h: string): string {
     display: inline-flex;
     align-items: center;
     gap: var(--space-sm);
-    background: var(--color-surface-card);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-pill);
+    background: var(--card);
+    border: var(--card-border-width) var(--card-border-style) var(--card-border);
+    border-radius: var(--pill-radius);
     padding: var(--space-xs) var(--space-md) var(--space-xs) var(--space-xs);
   }
 
@@ -63,7 +63,7 @@ function handleColor(h: string): string {
     flex-shrink: 0;
     width: 28px;
     height: 28px;
-    border-radius: 50%;
+    border-radius: var(--avatar-radius);
     object-fit: cover;
   }
 
@@ -71,7 +71,7 @@ function handleColor(h: string): string {
     flex-shrink: 0;
     width: 28px;
     height: 28px;
-    border-radius: 50%;
+    border-radius: var(--avatar-radius);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -91,25 +91,25 @@ function handleColor(h: string): string {
   .community-pill__name {
     font-size: var(--text-xs);
     font-weight: 600;
-    color: var(--neutral-900);
+    color: var(--card-foreground);
     line-height: 1.2;
     white-space: nowrap;
   }
 
   .community-pill__location {
     font-size: 9px;
-    color: var(--color-text-muted);
+    color: var(--foreground-muted);
     line-height: 1.2;
   }
 
   .community-pill__link {
     flex-shrink: 0;
-    color: var(--color-primary);
+    color: var(--primary);
     display: flex;
     padding: var(--space-xs);
     margin: calc(-1 * var(--space-xs));
   }
   .community-pill__link:hover {
-    color: var(--color-primary-hover);
+    color: var(--primary-hover);
   }
 </style>

--- a/src/components/EventCard.astro
+++ b/src/components/EventCard.astro
@@ -51,7 +51,7 @@ const sourceLabel = source ? `@${source.replace(/\.bsky\.social$/, '')}` : undef
     transition: border-color 0.15s ease;
   }
   .event-card:hover {
-    border-color: var(--blue-300);
+    border-color: var(--card-border-hover);
   }
 
   .event-card__link {
@@ -63,7 +63,7 @@ const sourceLabel = source ? `@${source.replace(/\.bsky\.social$/, '')}` : undef
   .event-card__date {
     font-size: var(--text-xs);
     font-weight: 600;
-    color: var(--color-primary);
+    color: var(--primary);
     text-transform: uppercase;
     letter-spacing: 0.03em;
   }
@@ -72,14 +72,14 @@ const sourceLabel = source ? `@${source.replace(/\.bsky\.social$/, '')}` : undef
     font-family: var(--font-body);
     font-weight: 600;
     font-size: var(--text-sm);
-    color: var(--neutral-900);
+    color: var(--card-foreground);
     margin-top: var(--space-xs);
     line-height: var(--leading-tight);
   }
 
   .event-card__desc {
     font-size: var(--text-xs);
-    color: var(--color-text-muted);
+    color: var(--foreground-muted);
     margin-top: var(--space-sm);
     display: -webkit-box;
     -webkit-line-clamp: 2;

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -47,10 +47,10 @@ const year = new Date().getFullYear();
 
 <style>
   .site-footer {
-    border-top: 1px solid var(--color-border);
+    border-top: 1px solid var(--footer-border);
     padding-block: var(--space-2xl);
     margin-top: var(--space-3xl);
-    background: var(--neutral-50);
+    background: var(--footer-bg);
   }
 
   .footer-inner {
@@ -63,7 +63,7 @@ const year = new Date().getFullYear();
 
   .footer-brand {
     font-size: var(--text-xs);
-    color: var(--color-text-muted);
+    color: var(--footer-fg-muted);
   }
 
   .footer-links {
@@ -73,6 +73,6 @@ const year = new Date().getFullYear();
     margin-top: var(--space-xs);
   }
   .footer-links span {
-    color: var(--color-text-muted);
+    color: var(--footer-fg-muted);
   }
 </style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,4 +1,6 @@
 ---
+import ThemeSwitcher from './ThemeSwitcher.astro';
+
 const navLinks = [
   { href: '/', label: 'Home' },
   { href: '/about', label: 'About' },
@@ -34,6 +36,9 @@ const currentPath = Astro.url.pathname;
           </a>
         </li>
       ))}
+      <li class="nav-theme">
+        <ThemeSwitcher />
+      </li>
     </ul>
   </nav>
 </header>
@@ -43,8 +48,8 @@ const currentPath = Astro.url.pathname;
     position: sticky;
     top: 0;
     z-index: 10;
-    background: var(--color-surface-card);
-    border-bottom: 1px solid var(--color-border);
+    background: var(--header-bg);
+    border-bottom: 1px solid var(--header-border);
   }
 
   .site-nav {
@@ -59,7 +64,7 @@ const currentPath = Astro.url.pathname;
     align-items: center;
     gap: var(--space-sm);
     text-decoration: none;
-    color: var(--color-primary);
+    color: var(--header-link);
   }
 
   .logo-cloud {
@@ -67,7 +72,7 @@ const currentPath = Astro.url.pathname;
     width: 22px;
     height: 12px;
     position: relative;
-    background: var(--blue-200);
+    background: var(--header-link-hover-bg);
     border-radius: 12px;
   }
   .logo-cloud::before {
@@ -76,7 +81,7 @@ const currentPath = Astro.url.pathname;
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    background: var(--blue-200);
+    background: var(--header-link-hover-bg);
     top: -5px;
     left: 4px;
   }
@@ -86,7 +91,7 @@ const currentPath = Astro.url.pathname;
     width: 7px;
     height: 7px;
     border-radius: 50%;
-    background: var(--blue-200);
+    background: var(--header-link-hover-bg);
     top: -3px;
     left: 12px;
   }
@@ -97,7 +102,7 @@ const currentPath = Astro.url.pathname;
     font-size: var(--text-base);
   }
   .logo-at {
-    color: var(--blue-400);
+    color: var(--header-link-inactive);
   }
 
   .nav-links {
@@ -109,15 +114,15 @@ const currentPath = Astro.url.pathname;
   .nav-link {
     font-size: var(--text-sm);
     font-weight: 500;
-    color: var(--color-text-muted);
+    color: var(--header-fg-muted);
     text-decoration: none;
     padding-block: var(--space-xs);
   }
   .nav-link:hover {
-    color: var(--color-text);
+    color: var(--header-fg);
   }
   .nav-link--active {
-    color: var(--color-primary);
+    color: var(--header-link);
   }
 
   /* Mobile hamburger */
@@ -132,7 +137,7 @@ const currentPath = Astro.url.pathname;
     display: block;
     width: 20px;
     height: 2px;
-    background: var(--color-text);
+    background: var(--header-fg);
     position: relative;
   }
   .hamburger::before,
@@ -141,7 +146,7 @@ const currentPath = Astro.url.pathname;
     position: absolute;
     width: 20px;
     height: 2px;
-    background: var(--color-text);
+    background: var(--header-fg);
     left: 0;
   }
   .hamburger::before { top: -6px; }
@@ -158,8 +163,8 @@ const currentPath = Astro.url.pathname;
       left: 0;
       right: 0;
       flex-direction: column;
-      background: var(--color-surface-card);
-      border-bottom: 1px solid var(--color-border);
+      background: var(--header-bg);
+      border-bottom: 1px solid var(--header-border);
       padding: var(--space-base) var(--space-lg);
       gap: var(--space-base);
       display: none;

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -47,7 +47,8 @@ const { subscriberCount = 1000, groupCount = 10 } = Astro.props;
   .hero {
     position: relative;
     overflow: hidden;
-    background: var(--color-primary);
+    background: var(--hero-bg);
+    border: var(--hero-border-width) var(--hero-border-style) var(--hero-border-color);
     padding-block: var(--space-3xl) var(--space-3xl);
   }
 
@@ -62,6 +63,7 @@ const { subscriberCount = 1000, groupCount = 10 } = Astro.props;
     position: absolute;
     inset: 0;
     pointer-events: none;
+    display: var(--hero-cloud-display);
   }
 
   .cloud {
@@ -141,12 +143,14 @@ const { subscriberCount = 1000, groupCount = 10 } = Astro.props;
   }
 
   .hero h1 {
-    color: var(--color-text-on-primary);
+    color: var(--hero-title);
+    text-shadow: var(--hero-title-shadow);
+    font-style: var(--hero-title-style);
     max-width: 28ch;
   }
 
   .hero-sub {
-    color: oklch(100% 0 0 / 0.75);
+    color: var(--hero-subtitle);
     font-size: var(--text-base);
     max-width: 50ch;
     margin-top: var(--space-md);
@@ -162,29 +166,34 @@ const { subscriberCount = 1000, groupCount = 10 } = Astro.props;
   }
 
   .btn--hero {
-    background: var(--color-text-on-primary);
-    color: var(--color-primary);
+    background: var(--hero-cta-bg);
+    color: var(--hero-cta-fg);
+    border: var(--hero-cta-border);
     padding: var(--space-md) var(--space-lg);
-    border-radius: var(--radius-sm);
+    border-radius: var(--btn-radius);
     font-family: var(--font-body);
     font-size: var(--text-sm);
     font-weight: 600;
     text-decoration: none;
+    text-transform: var(--btn-primary-text-transform);
     transition: opacity 0.15s ease;
+    animation: var(--hero-cta-animation);
   }
   .btn--hero:hover {
     opacity: 0.9;
-    color: var(--color-primary);
+    color: var(--hero-cta-fg);
   }
 
   .hero-secondary {
-    color: oklch(100% 0 0 / 0.85);
+    color: var(--hero-fg);
     font-size: var(--text-sm);
     font-weight: 500;
     text-decoration: none;
+    opacity: 0.85;
   }
   .hero-secondary:hover {
-    color: var(--color-text-on-primary);
+    color: var(--hero-fg);
+    opacity: 1;
   }
 
   .hero-stats {
@@ -192,7 +201,7 @@ const { subscriberCount = 1000, groupCount = 10 } = Astro.props;
     gap: var(--space-2xl);
     margin-top: var(--space-2xl);
     padding-top: var(--space-lg);
-    border-top: 1px solid oklch(100% 0 0 / 0.12);
+    border-top: 1px solid color-mix(in oklch, var(--hero-fg) 15%, transparent);
   }
 
   .hero-stat__number {
@@ -200,14 +209,14 @@ const { subscriberCount = 1000, groupCount = 10 } = Astro.props;
     font-family: var(--font-body);
     font-weight: 700;
     font-size: var(--text-xl);
-    color: var(--color-text-on-primary);
+    color: var(--hero-fg);
   }
 
   .hero-stat__label {
     font-size: var(--text-xs);
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: oklch(100% 0 0 / 0.55);
+    color: var(--hero-fg-muted);
     font-weight: 600;
   }
 

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -54,13 +54,13 @@ const initials = author
 
 <style>
   .post-card {
-    background: var(--color-surface-card);
-    border: 1px solid var(--color-border);
+    background: var(--card);
+    border: 1px solid var(--card-border);
     border-radius: var(--radius-md);
     transition: border-color 0.15s ease;
   }
   .post-card:hover {
-    border-color: var(--blue-300);
+    border-color: var(--card-border-hover);
   }
 
   .post-card__link {
@@ -101,13 +101,13 @@ const initials = author
     font-family: var(--font-body);
     font-weight: 600;
     font-size: var(--text-sm);
-    color: var(--neutral-900);
+    color: var(--card-foreground);
     line-height: var(--leading-tight);
   }
 
   .post-card__excerpt {
     font-size: var(--text-xs);
-    color: var(--color-text-muted);
+    color: var(--foreground-muted);
     margin-top: var(--space-xs);
     display: -webkit-box;
     -webkit-line-clamp: 2;
@@ -122,16 +122,16 @@ const initials = author
     gap: var(--space-sm);
     margin-top: var(--space-sm);
     font-size: var(--text-xs);
-    color: var(--color-text-muted);
+    color: var(--foreground-muted);
   }
 
   .post-card__author {
     font-weight: 500;
-    color: var(--color-text-secondary);
+    color: var(--foreground-secondary);
   }
 
   .post-card__date {
-    color: var(--neutral-400);
+    color: var(--separator-fg);
   }
   .post-card__date::before {
     content: '·';

--- a/src/components/ThemeSwitcher.astro
+++ b/src/components/ThemeSwitcher.astro
@@ -1,0 +1,104 @@
+---
+import { themes, defaultThemeId, storageKey } from '../lib/themes';
+
+const themeIds = themes.map(t => t.id);
+const themeLabels = Object.fromEntries(themes.map(t => [t.id, t.name]));
+---
+
+<button
+  type="button"
+  class="theme-toggle"
+  data-theme-toggle
+  data-themes={JSON.stringify(themeIds)}
+  data-labels={JSON.stringify(themeLabels)}
+  data-default={defaultThemeId}
+  data-storage-key={storageKey}
+  aria-label="Cycle theme"
+>
+  <svg class="theme-toggle__icon" width="14" height="14" viewBox="0 0 24 24"
+       fill="none" stroke="currentColor" stroke-width="2"
+       stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="13.5" cy="6.5" r=".5" fill="currentColor" />
+    <circle cx="17.5" cy="10.5" r=".5" fill="currentColor" />
+    <circle cx="8.5" cy="7.5" r=".5" fill="currentColor" />
+    <circle cx="6.5" cy="12.5" r=".5" fill="currentColor" />
+    <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z" />
+  </svg>
+  <span class="theme-toggle__label" data-theme-label></span>
+</button>
+
+<script>
+  const btn = document.querySelector<HTMLButtonElement>('[data-theme-toggle]');
+  if (btn) {
+    const themes: string[] = JSON.parse(btn.dataset.themes ?? '[]');
+    const labels: Record<string, string> = JSON.parse(btn.dataset.labels ?? '{}');
+    const fallback = btn.dataset.default ?? themes[0];
+    const key = btn.dataset.storageKey ?? 'atc-theme';
+    const labelEl = btn.querySelector<HTMLElement>('[data-theme-label]');
+
+    const sync = () => {
+      const current = document.documentElement.dataset.theme || fallback;
+      if (labelEl) labelEl.textContent = labels[current] ?? current;
+      btn.setAttribute('aria-label', `Theme: ${labels[current] ?? current}. Click to switch.`);
+    };
+    sync();
+
+    btn.addEventListener('click', () => {
+      const current = document.documentElement.dataset.theme || fallback;
+      const idx = themes.indexOf(current);
+      const next = themes[(idx + 1) % themes.length];
+      if (next === fallback) {
+        document.documentElement.removeAttribute('data-theme');
+      } else {
+        document.documentElement.dataset.theme = next;
+      }
+      try {
+        localStorage.setItem(key, next);
+      } catch {
+        /* storage unavailable — ignore */
+      }
+      sync();
+    });
+  }
+</script>
+
+<style>
+  .theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xs);
+    height: 28px;
+    padding: 0 var(--space-sm);
+    background: transparent;
+    color: var(--header-fg-muted);
+    border: 1px solid var(--header-border);
+    border-radius: var(--pill-radius);
+    font-family: inherit;
+    font-size: var(--text-xs);
+    font-weight: 500;
+    cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+  }
+
+  .theme-toggle:hover {
+    color: var(--header-fg);
+    background: var(--header-link-hover-bg);
+    border-color: color-mix(in oklch, var(--header-fg) 30%, transparent);
+  }
+
+  .theme-toggle:focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+  }
+
+  .theme-toggle__icon {
+    flex-shrink: 0;
+  }
+
+  /* Hide label on very narrow screens; icon-only there */
+  @media (max-width: 480px) {
+    .theme-toggle__label {
+      display: none;
+    }
+  }
+</style>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -3,17 +3,23 @@ interface Props {
   title: string;
   description?: string;
   ogImage?: string;
+  defaultTheme?: string;
 }
 
 const {
   title,
   description = 'The community hub for apps and people building on AT Protocol',
   ogImage,
+  defaultTheme,
 } = Astro.props;
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 import '../styles/global.css';
+import { themes, defaultThemeId, storageKey } from '../lib/themes';
+
+const themeIds = themes.map(t => t.id);
+const initialTheme = defaultTheme ?? null;
 ---
 
 <!doctype html>
@@ -22,6 +28,39 @@ import '../styles/global.css';
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="generator" content={Astro.generator} />
+
+    {/*
+      Theme resolution (pre-paint, no FOUC):
+        1. localStorage — anonymous-user preference
+        2. initialTheme — page-level prop (e.g. profile owner's theme)
+        3. defaultThemeId — fallback (no data-theme attribute set)
+
+      TODO: once login lands, fetch the logged-in user's theme
+      preference from their PDS and inject it as a third tier above
+      localStorage (server-rendered into `initialTheme` so the
+      first paint matches what the user picked on another device).
+    */}
+    <script
+      is:inline
+      define:vars={{ themeIds, initialTheme, defaultThemeId, storageKey }}
+    >
+      (function () {
+        try {
+          var stored = localStorage.getItem(storageKey);
+          var pick = null;
+          if (stored && themeIds.indexOf(stored) !== -1) {
+            pick = stored;
+          } else if (initialTheme && themeIds.indexOf(initialTheme) !== -1) {
+            pick = initialTheme;
+          }
+          if (pick && pick !== defaultThemeId) {
+            document.documentElement.setAttribute('data-theme', pick);
+          }
+        } catch (e) {
+          /* storage unavailable — fall back to default */
+        }
+      })();
+    </script>
 
     <title>{title} — atmosphere.community</title>
     <meta name="description" content={description} />

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -1,0 +1,15 @@
+export interface Theme {
+  id: string;
+  name: string;
+  scheme: 'light' | 'dark';
+}
+
+export const themes: Theme[] = [
+  { id: 'horizon', name: 'Horizon', scheme: 'light' },
+  { id: 'blacksky', name: 'Blacksky', scheme: 'dark' },
+  { id: 'ngerakines', name: 'ngerakines', scheme: 'light' },
+  { id: 'fujocoded', name: 'Fujocoded', scheme: 'light' },
+];
+
+export const defaultThemeId = 'horizon';
+export const storageKey = 'atc-theme';

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -133,7 +133,7 @@ import Footer from "../components/Footer.astro";
 
     .prose code {
         font-size: 0.9em;
-        background: var(--neutral-100);
+        background: var(--muted);
         padding: 2px 6px;
         border-radius: var(--radius-sm);
     }

--- a/src/pages/communities.astro
+++ b/src/pages/communities.astro
@@ -62,7 +62,7 @@ for (let i = 0; i < communities.length; i++) {
   }
 
   .communities-sub {
-    color: var(--color-text-secondary);
+    color: var(--foreground-secondary);
     font-size: var(--text-sm);
     max-width: 55ch;
     line-height: var(--leading-relaxed);
@@ -84,6 +84,6 @@ for (let i = 0; i < communities.length; i++) {
 
   .community-desc {
     font-size: var(--text-sm);
-    color: var(--color-text-secondary);
+    color: var(--foreground-secondary);
   }
 </style>

--- a/src/pages/community-content.astro
+++ b/src/pages/community-content.astro
@@ -108,7 +108,7 @@ const mergedPosts = allPosts
   }
 
   .content-sub {
-    color: var(--color-text-secondary);
+    color: var(--foreground-secondary);
     font-size: var(--text-sm);
     max-width: 55ch;
     line-height: var(--leading-relaxed);
@@ -125,8 +125,8 @@ const mergedPosts = allPosts
     margin-top: var(--space-xl);
     padding: var(--space-2xl);
     text-align: center;
-    color: var(--color-text-secondary);
-    background: var(--neutral-100);
+    color: var(--foreground-secondary);
+    background: var(--muted);
     border-radius: var(--radius-md);
   }
 </style>

--- a/src/pages/events.astro
+++ b/src/pages/events.astro
@@ -77,7 +77,7 @@ const upcomingEvents = [...directEvents, ...sharedEvents].filter(e => {
   }
 
   .events-sub {
-    color: var(--color-text-secondary);
+    color: var(--foreground-secondary);
     font-size: var(--text-sm);
     max-width: 55ch;
     line-height: var(--leading-relaxed);
@@ -91,8 +91,8 @@ const upcomingEvents = [...directEvents, ...sharedEvents].filter(e => {
     margin-top: var(--space-xl);
     padding: var(--space-2xl);
     text-align: center;
-    color: var(--color-text-secondary);
-    background: var(--neutral-100);
+    color: var(--foreground-secondary);
+    background: var(--muted);
     border-radius: var(--radius-md);
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -227,7 +227,7 @@ const highlights = [
 
 <style>
   .section--alt {
-    background: var(--neutral-100);
+    background: var(--muted);
   }
 
   .section-header {
@@ -262,7 +262,7 @@ const highlights = [
   }
   .highlight-card p {
     font-size: var(--text-xs);
-    color: var(--color-text-muted);
+    color: var(--foreground-muted);
     line-height: var(--leading-normal);
   }
   .highlight-card a {
@@ -277,8 +277,8 @@ const highlights = [
   .empty-state {
     padding: var(--space-xl);
     text-align: center;
-    color: var(--color-text-secondary);
-    background: var(--neutral-100);
+    color: var(--foreground-secondary);
+    background: var(--muted);
     border-radius: var(--radius-md);
     font-size: var(--text-sm);
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,89 +1,40 @@
 /* ============================================
    atmosphere.community — Design System
-   Direction: "Horizon" — warm, breezy, people-forward
+   Default theme: "horizon" - warm, breezy, people-forward
+   Layering:
+     tokens.base       — base tokens, themes redefine here
+     tokens.semantic   — semantic mappings (theme-agnostic)
+     tokens.components — scoped component tokens
+     global            — reset, base elements, components
    ============================================ */
 
-/* --- Fonts --- */
-/* Bitter (display): warm slab serif for headings
-   Source Sans 3 (body): humanist sans for text/UI */
+@import "./tokens.base.css";
+@import "./tokens.semantic.css";
+@import "./tokens.components.css";
 
-/* --- Color Tokens (OKLCH) --- */
+/* --- Structural tokens (NOT themed) --- */
 :root {
-  /* Brand blues — hue ~250 (sky blue family) */
-  --blue-900: oklch(25% 0.08 250);
-  --blue-800: oklch(32% 0.09 250);
-  --blue-700: oklch(48% 0.14 250);
-  --blue-600: oklch(56% 0.13 250);
-  --blue-500: oklch(62% 0.11 250);
-  --blue-400: oklch(68% 0.10 250);
-  --blue-300: oklch(75% 0.08 250);
-  --blue-200: oklch(85% 0.05 250);
-  --blue-100: oklch(90% 0.03 250);
-  --blue-50:  oklch(95% 0.015 250);
-
-  /* Neutrals — tinted toward brand hue 250 */
-  --neutral-900: oklch(22% 0.01 250);
-  --neutral-800: oklch(30% 0.01 250);
-  --neutral-700: oklch(38% 0.01 250);
-  --neutral-600: oklch(48% 0.008 250);
-  --neutral-500: oklch(58% 0.008 250);
-  --neutral-400: oklch(68% 0.006 250);
-  --neutral-300: oklch(78% 0.005 250);
-  --neutral-200: oklch(88% 0.008 250);
-  --neutral-100: oklch(93% 0.008 250);
-  --neutral-50:  oklch(97% 0.005 250);
-
-  /* Accent: teal for communities/events */
-  --teal-600: oklch(55% 0.12 170);
-  --teal-100: oklch(92% 0.03 170);
-
-  /* Accent: coral for warm highlights */
-  --coral-600: oklch(55% 0.14 30);
-  --coral-100: oklch(92% 0.03 30);
-
-  /* Semantic */
-  --color-primary: var(--blue-700);
-  --color-primary-hover: var(--blue-800);
-  --color-text: var(--neutral-900);
-  --color-text-secondary: var(--neutral-600);
-  --color-text-muted: var(--neutral-500);
-  --color-text-on-primary: oklch(98% 0.005 250);
-  --color-surface: oklch(99% 0.004 250);
-  --color-surface-card: oklch(100% 0.002 250);
-  --color-border: var(--neutral-200);
-  --color-link: var(--blue-700);
-  --color-link-hover: var(--blue-800);
-
-  /* Location/status badges */
-  --badge-location-bg: oklch(94% 0.025 145);
-  --badge-location-text: oklch(38% 0.08 145);
-  --badge-online-bg: var(--blue-50);
-  --badge-online-text: var(--blue-700);
-  --badge-tag-bg: var(--blue-50);
-  --badge-tag-text: var(--blue-700);
-
   /* --- Spacing (4pt base) --- */
-  --space-xs:  4px;
-  --space-sm:  8px;
-  --space-md:  12px;
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 12px;
   --space-base: 16px;
-  --space-lg:  24px;
-  --space-xl:  32px;
+  --space-lg: 24px;
+  --space-xl: 32px;
   --space-2xl: 48px;
   --space-3xl: 64px;
   --space-4xl: 96px;
 
   /* --- Typography --- */
-  --font-display: 'Bitter', Georgia, serif;
-  --font-body: 'Source Sans 3', 'Source Sans Pro', system-ui, sans-serif;
+  --font-display: "Bitter", Georgia, serif;
+  --font-body: "Source Sans 3", "Source Sans Pro", system-ui, sans-serif;
 
-  /* Type scale — ~1.3 ratio (perfect fourth) */
-  --text-xs:   clamp(0.65rem, 0.6rem + 0.2vw, 0.75rem);
-  --text-sm:   clamp(0.78rem, 0.74rem + 0.2vw, 0.875rem);
+  --text-xs: clamp(0.65rem, 0.6rem + 0.2vw, 0.75rem);
+  --text-sm: clamp(0.78rem, 0.74rem + 0.2vw, 0.875rem);
   --text-base: clamp(0.875rem, 0.84rem + 0.2vw, 1rem);
-  --text-lg:   clamp(1.1rem, 1rem + 0.3vw, 1.25rem);
-  --text-xl:   clamp(1.4rem, 1.2rem + 0.6vw, 1.75rem);
-  --text-2xl:  clamp(1.75rem, 1.4rem + 1vw, 2.25rem);
+  --text-lg: clamp(1.1rem, 1rem + 0.3vw, 1.25rem);
+  --text-xl: clamp(1.4rem, 1.2rem + 0.6vw, 1.75rem);
+  --text-2xl: clamp(1.75rem, 1.4rem + 1vw, 2.25rem);
 
   --leading-tight: 1.2;
   --leading-normal: 1.55;
@@ -114,8 +65,12 @@ html {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  html { scroll-behavior: auto; }
-  *, *::before, *::after {
+  html {
+    scroll-behavior: auto;
+  }
+  *,
+  *::before,
+  *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
@@ -126,46 +81,64 @@ body {
   font-family: var(--font-body);
   font-size: var(--text-base);
   line-height: var(--leading-normal);
-  color: var(--color-text);
-  background: var(--color-surface);
+  color: var(--foreground);
+  background: var(--background);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   min-height: 100dvh;
 }
 
-img, svg {
+img,
+svg {
   display: block;
   max-width: 100%;
   height: auto;
 }
 
 a {
-  color: var(--color-link);
+  color: var(--link);
   text-decoration: none;
   transition: color 0.15s ease;
 }
 a:hover {
-  color: var(--color-link-hover);
+  color: var(--link-hover);
 }
 a:focus-visible {
-  outline: 2px solid var(--color-primary);
+  outline: 2px solid var(--ring);
   outline-offset: 2px;
   border-radius: 2px;
 }
 
-h1, h2, h3, h4 {
+h1,
+h2,
+h3,
+h4 {
   font-family: var(--font-display);
   line-height: var(--leading-tight);
-  color: var(--neutral-900);
+  color: var(--foreground);
   text-wrap: balance;
 }
 
-h1 { font-size: var(--text-2xl); font-weight: 700; }
-h2 { font-size: var(--text-xl);  font-weight: 600; }
-h3 { font-size: var(--text-lg);  font-weight: 600; }
-h4 { font-size: var(--text-base); font-weight: 600; }
+h1 {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+}
+h2 {
+  font-size: var(--text-xl);
+  font-weight: 600;
+}
+h3 {
+  font-size: var(--text-lg);
+  font-weight: 600;
+}
+h4 {
+  font-size: var(--text-base);
+  font-weight: 600;
+}
 
-p + p { margin-top: var(--space-base); }
+p + p {
+  margin-top: var(--space-base);
+}
 
 /* --- Utility Classes --- */
 .container {
@@ -199,9 +172,11 @@ p + p { margin-top: var(--space-base); }
 
 /* --- Card base --- */
 .card {
-  background: var(--color-surface-card);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
+  background: var(--card);
+  color: var(--card-foreground);
+  border: var(--card-border-width) var(--card-border-style) var(--card-border);
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-shadow);
   padding: var(--space-base);
 }
 
@@ -210,7 +185,7 @@ p + p { margin-top: var(--space-base); }
   display: inline-flex;
   align-items: center;
   padding: var(--space-xs) var(--space-sm);
-  border-radius: var(--radius-pill);
+  border-radius: var(--pill-radius);
   font-size: var(--text-xs);
   font-weight: 600;
   line-height: 1;
@@ -219,17 +194,17 @@ p + p { margin-top: var(--space-base); }
 
 .badge--tag {
   background: var(--badge-tag-bg);
-  color: var(--badge-tag-text);
+  color: var(--badge-tag-fg);
 }
 
 .badge--location {
   background: var(--badge-location-bg);
-  color: var(--badge-location-text);
+  color: var(--badge-location-fg);
 }
 
 .badge--online {
   background: var(--badge-online-bg);
-  color: var(--badge-online-text);
+  color: var(--badge-online-fg);
 }
 
 /* --- Button --- */
@@ -239,33 +214,49 @@ p + p { margin-top: var(--space-base); }
   gap: var(--space-sm);
   padding: var(--space-sm) var(--space-base);
   border: none;
-  border-radius: var(--radius-sm);
+  border-radius: var(--btn-radius);
   font-family: var(--font-body);
   font-size: var(--text-sm);
   font-weight: 600;
   line-height: 1;
   cursor: pointer;
-  transition: background 0.15s ease, color 0.15s ease;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.2s ease,
+    transform 0.15s cubic-bezier(0.25, 1, 0.5, 1);
   text-decoration: none;
 }
 
 .btn--primary {
-  background: var(--color-primary);
-  color: var(--color-text-on-primary);
+  background: var(--btn-primary-bg);
+  color: var(--btn-primary-fg);
+  border: var(--btn-primary-border-width) var(--btn-primary-border-style)
+    var(--btn-primary-border-color);
+  text-transform: var(--btn-primary-text-transform);
+  animation: var(--btn-primary-animation);
+  box-shadow: var(--btn-primary-shadow);
 }
 .btn--primary:hover {
-  background: var(--color-primary-hover);
-  color: var(--color-text-on-primary);
+  background: var(--btn-primary-bg-hover);
+  color: var(--btn-primary-fg);
+  box-shadow: var(--btn-primary-shadow-hover);
+  transform: translateY(var(--btn-primary-translate-hover));
+}
+.btn--primary:active {
+  box-shadow: var(--btn-primary-shadow-active);
+  transform: translateY(var(--btn-primary-translate-active));
 }
 
 .btn--ghost {
   background: transparent;
-  color: var(--color-primary);
-  border: 1px solid var(--color-border);
+  color: var(--primary);
+  border: 1px solid var(--btn-ghost-border);
 }
 .btn--ghost:hover {
-  background: var(--blue-50);
-  border-color: var(--blue-200);
+  background: var(--btn-ghost-bg-hover);
+  border-color: var(--btn-ghost-border-hover);
 }
 
 .btn--small {
@@ -293,7 +284,7 @@ p + p { margin-top: var(--space-base); }
 }
 
 .section__subtitle {
-  color: var(--color-text-secondary);
+  color: var(--foreground-secondary);
   font-size: var(--text-sm);
   margin-top: var(--space-xs);
 }
@@ -316,8 +307,8 @@ p + p { margin-top: var(--space-base); }
   top: -100%;
   left: var(--space-base);
   padding: var(--space-sm) var(--space-base);
-  background: var(--color-primary);
-  color: var(--color-text-on-primary);
+  background: var(--primary);
+  color: var(--primary-foreground);
   border-radius: var(--radius-sm);
   font-weight: 600;
   z-index: 100;

--- a/src/styles/themes/_template.css
+++ b/src/styles/themes/_template.css
@@ -1,0 +1,194 @@
+/* ============================================
+   Theme: <name>
+   Mood: <one-line vibe — what's the feel?>
+   Source: <link to inspiration / brand guide / aesthetic ref>
+
+   Applied via <html data-theme="<name>">.
+
+   ⚠ READ THE README FIRST — see the "Contributing a theme"
+   section in /README.md for the full process, layering rules,
+   contrast requirements, and gotchas.
+
+   Quick recap (don't skip step 3 — your theme won't load
+   anywhere without registering it):
+     1. Copy this file → src/styles/themes/<name>.css
+     2. Replace every REPLACE_ME with your theme id
+     3. REGISTER:
+        a. Add `@import "./themes/<name>.css";` to tokens.base.css
+        b. Add an entry to `themes` in src/lib/themes.ts
+     4. Run `npm run dev` and cycle to it via the header toggle.
+   ============================================ */
+
+:root[data-theme="REPLACE_ME"] {
+  /* ============================================================
+     1. BASE TOKENS — required.
+     Plain colors only (hex / rgb / oklch). No var() chains.
+     ============================================================ */
+
+  /* Surface ramp + paired content.
+     Light themes: 100 = page bg, ramps up to darker shades.
+     Dark themes:  100 = page bg (darkest), ramps UP in lightness
+                   with elevation (cards/borders are lighter). */
+  --color-base-100: #ffffff;
+  --color-base-200: #f4f4f5;
+  --color-base-300: #e4e4e7;
+  --color-base-content: #1a1a1a;
+
+  /* Brand pairs — every `*-content` MUST hit ≥4.5:1
+     contrast on its paired surface. */
+  --color-primary: #5b6cff;
+  --color-primary-content: #ffffff;
+
+  --color-secondary: #8b5cf6;
+  --color-secondary-content: #ffffff;
+
+  --color-accent: #f59e0b;
+  --color-accent-content: #1a1a1a;
+
+  --color-neutral: #52525b;
+  --color-neutral-content: #ffffff;
+
+  /* Status pairs */
+  --color-info: #3b82f6;
+  --color-info-content: #ffffff;
+
+  --color-success: #16a34a;
+  --color-success-content: #ffffff;
+
+  --color-warning: #f59e0b;
+  --color-warning-content: #1a1a1a;
+
+  --color-error: #dc2626;
+  --color-error-content: #ffffff;
+
+  /* ============================================================
+     2. FONTS — optional.
+     Themes MAY override --font-display and --font-body.
+     This is a deliberate carve-out from "no structural theming"
+     because vibe often hinges on type. Don't override --space-*,
+     --text-* sizes, --leading-*, breakpoints, or motion durations.
+     ============================================================ */
+  /* --font-display: "Your Display Font", Georgia, serif; */
+  /* --font-body:    "Your Body Font", system-ui, sans-serif; */
+
+  /* ============================================================
+     3. COMPONENT OVERRIDES — optional.
+     Each line below overrides a default from tokens.components.css.
+     Delete the ones you don't change. Add as needed.
+     ============================================================ */
+
+  /* --- Card --- */
+  /* --card: var(--color-base-100); */
+  /* --card-radius: 10px; */
+  /* --card-border: var(--color-base-300); */
+  /* --card-border-width: 1px; */
+  /* --card-border-style: solid; */
+  /* --card-shadow: 0 1px 2px rgba(0, 0, 0, 0.05); */
+
+  /* --- Pills (badges, community pills, theme toggle) --- */
+  /* --pill-radius: 999px; */    /* set to 0 for retro / square themes */
+  /* --avatar-radius: 50%; */    /* avatar circles inside community pills */
+
+  /* --- Buttons --- */
+  /* --btn-radius: 6px; */
+  /* --btn-primary-bg: var(--primary); */
+  /* --btn-primary-bg-hover: var(--primary-hover); */
+  /* --btn-primary-fg: var(--primary-foreground); */
+  /* --btn-primary-border-style: none; */
+  /* --btn-primary-border-width: 0; */
+  /* --btn-primary-border-color: transparent; */
+  /* --btn-primary-text-transform: none; */
+  /* --btn-primary-animation: none; */
+  /* --btn-primary-shadow: none; */
+  /* --btn-primary-shadow-hover: none; */
+  /* --btn-primary-shadow-active: none; */
+  /* --btn-primary-translate-hover: 0; */
+  /* --btn-primary-translate-active: 0; */
+  /* --btn-ghost-border: var(--border); */
+  /* --btn-ghost-bg-hover: var(--primary-muted); */
+  /* --btn-ghost-border-hover: ...; */
+
+  /* --- Header --- */
+  /* --header-bg: var(--card); */
+  /* --header-border: var(--border); */
+  /* --header-fg: var(--foreground); */
+  /* --header-fg-muted: var(--foreground-muted); */
+  /* --header-link: var(--primary); */
+  /* --header-link-hover-bg: ...; */
+  /* --header-link-inactive: ...; */
+
+  /* --- Footer --- */
+  /* --footer-bg: var(--muted); */
+  /* --footer-border: var(--border); */
+  /* --footer-fg-muted: var(--foreground-muted); */
+
+  /* --- Hero --- */
+  /* --hero-bg: var(--primary); */              /* solid, gradient, or url() ok */
+  /* --hero-fg: var(--primary-foreground); */
+  /* --hero-fg-muted: ...; */
+  /* --hero-title: ...; */
+  /* --hero-title-shadow: none; */
+  /* --hero-title-style: normal; */
+  /* --hero-subtitle: ...; */
+  /* --hero-border-style: none; */
+  /* --hero-border-width: 0; */
+  /* --hero-border-color: transparent; */
+  /* --hero-cta-bg: ...; */
+  /* --hero-cta-fg: ...; */
+  /* --hero-cta-border: none; */
+  /* --hero-cta-animation: none; */
+  /* --hero-cloud-display: block; */            /* "none" hides the floating clouds */
+
+  /* --- Badges --- */
+  /* --badge-tag-bg: var(--primary-muted); */
+  /* --badge-tag-fg: var(--primary-muted-foreground); */
+  /* --badge-online-bg: var(--primary-muted); */
+  /* --badge-online-fg: var(--primary-muted-foreground); */
+  /* --badge-location-bg: var(--success-muted); */
+  /* --badge-location-fg: var(--success-muted-foreground); */
+}
+
+/* ============================================================
+   4. THEME-SCOPED RAW CSS — optional, last resort.
+   For patterns that can't be expressed via tokens — animated
+   backgrounds, body overlays, decorative pseudo-elements.
+   Always scope to :root[data-theme="<name>"] so other themes
+   are unaffected.
+   ============================================================ */
+
+/* Example: full-page gradient background + faint grid overlay
+   (uncomment and adapt)
+:root[data-theme="REPLACE_ME"] body {
+  background: linear-gradient(180deg, #abc 0%, #fed 100%);
+  background-attachment: fixed;
+  position: relative;
+  isolation: isolate;
+}
+
+:root[data-theme="REPLACE_ME"] body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image:
+    linear-gradient(to right, white 1px, transparent 1px),
+    linear-gradient(to bottom, white 1px, transparent 1px);
+  background-size: 28px 28px;
+  opacity: 0.08;
+  pointer-events: none;
+  z-index: 0;
+}
+
+:root[data-theme="REPLACE_ME"] body > *:not(.skip-link) {
+  position: relative;
+  z-index: 1;
+}
+*/
+
+/* Always honor reduced motion if your theme animates anything.
+@media (prefers-reduced-motion: reduce) {
+  :root[data-theme="REPLACE_ME"] {
+    --btn-primary-animation: none;
+    --btn-primary-translate-hover: 0;
+  }
+}
+*/

--- a/src/styles/themes/blacksky.css
+++ b/src/styles/themes/blacksky.css
@@ -1,0 +1,61 @@
+/* ============================================
+   Theme: blacksky
+   Mood: deep indigo dark mode — ported from atmosphereconf
+
+   Applied via <html data-theme="blacksky">.
+
+   See tokens.base.css for the rules every theme follows.
+   ============================================ */
+
+:root[data-theme="blacksky"] {
+  /* --- Base tokens (required) ---
+     Surfaces step UP in lightness with elevation in dark themes:
+     base-100 (page bg) is darkest, base-200 (cards/muted) is lighter,
+     base-300 (borders/raised) lighter still. */
+  --color-base-100: #0f1729;
+  --color-base-200: #182040;
+  --color-base-300: #232c54;
+  --color-base-content: #e8eaf0;
+
+  /* Brand: indigo accent from atmosphereconf */
+  --color-primary: #6b7bf5;
+  --color-primary-content: #e8eaf0;
+
+  --color-secondary: #252b3f;
+  --color-secondary-content: #e8eaf0;
+
+  --color-accent: #182040;
+  --color-accent-content: #e8eaf0;
+
+  --color-neutral: #a8adc0;
+  --color-neutral-content: #0f1729;
+
+  /* Status — dark-mode tuned (lower chroma, lifted lightness) */
+  --color-info: #6b7bf5;
+  --color-info-content: #e8eaf0;
+
+  --color-success: #48c878;
+  --color-success-content: #0f1729;
+
+  --color-warning: #f5c060;
+  --color-warning-content: #1a1408;
+
+  --color-error: #f56b6b;
+  --color-error-content: #1a0808;
+
+  /* --- Component overrides --- */
+
+  /* Header sits darker than the page bg */
+  --header-bg: #0a0e1a;
+  --header-border: rgba(255, 255, 255, 0.1);
+  --header-fg-muted: rgba(232, 234, 240, 0.6);
+  --header-link-hover-bg: rgba(255, 255, 255, 0.08);
+
+  /* Cards: subtle lift on a dark page */
+  --card-border: rgba(255, 255, 255, 0.08);
+  --card-border-hover: color-mix(in oklch, var(--primary) 50%, var(--background));
+
+  /* Footer: lifted from page bg */
+  --footer-bg: var(--color-base-200);
+  --footer-border: rgba(255, 255, 255, 0.08);
+}

--- a/src/styles/themes/fujocoded.css
+++ b/src/styles/themes/fujocoded.css
@@ -1,0 +1,173 @@
+/* ============================================
+   Theme: fujocoded
+   Source: fujocoded.com (ported from atmosphereconf)
+
+   Vibe ingredients (in order of importance):
+   1. Lavender → blush body gradient with a faint white grid
+   2. Glass navbar (translucent + backdrop-blur)
+   3. Signature 3D primary button — gradient + inset
+      highlights + outer drop, lifts on hover
+   4. White cards on the gradient
+
+   Applied via <html data-theme="fujocoded">.
+   ============================================ */
+
+:root[data-theme="fujocoded"] {
+  /* --- Base tokens --- */
+  --color-base-100: #b89ffc; /* lavender (page accent below the gradient) */
+  --color-base-200: #ffffff; /* card surface */
+  --color-base-300: #4d2e91; /* deep purple — strokes/borders */
+  --color-base-content: #4d2e91; /* deep purple body text */
+
+  /* Brand: hot pink primary, deep purple secondary, magenta accent */
+  --color-primary: #ff38eb;
+  --color-primary-content: #ffffff;
+
+  --color-secondary: #4d2e91;
+  --color-secondary-content: #ffffff;
+
+  --color-accent: #ce00ff;
+  --color-accent-content: #ffffff;
+
+  --color-neutral: #7a5fbd;
+  --color-neutral-content: #ffffff;
+
+  /* Status — pulled from fujocoded event-badge palette */
+  --color-info: #4360f7;
+  --color-info-content: #ffffff;
+
+  --color-success: #3da828;
+  --color-success-content: #ffffff;
+
+  --color-warning: #b88a00;
+  --color-warning-content: #ffffff;
+
+  --color-error: #d45200;
+  --color-error-content: #ffffff;
+
+  /* --- Component overrides --- */
+
+  /* Cards: soft purple shadow, gentle 8px radius */
+  --card: rgba(255, 255, 255, 0.85);
+  --card-radius: 8px;
+  --card-border-width: 0;
+  --card-border-style: solid;
+  --card-shadow:
+    0 10px 22px rgba(77, 46, 145, 0.16),
+    0 3px 8px rgba(42, 26, 76, 0.1);
+
+  /* Header: glass — translucent white + backdrop-blur (set below) */
+  --header-bg: rgba(255, 255, 255, 0.55);
+  --header-border: transparent;
+  --header-fg: #4d2e91;
+  --header-fg-muted: rgba(77, 46, 145, 0.6);
+  --header-link: #ff38eb;
+  --header-link-hover-bg: rgba(255, 56, 235, 0.12);
+  --header-link-inactive: rgba(77, 46, 145, 0.5);
+
+  /* Footer: also glass */
+  --footer-bg: rgba(255, 255, 255, 0.5);
+  --footer-border: rgba(77, 46, 145, 0.15);
+  --footer-fg-muted: rgba(77, 46, 145, 0.7);
+
+  /* Hero: white card on the gradient with a strong purple drop */
+  --hero-bg: rgba(255, 255, 255, 0.85);
+  --hero-fg: #4d2e91;
+  --hero-fg-muted: rgba(77, 46, 145, 0.7);
+  --hero-title: #4d2e91;
+  --hero-subtitle: rgba(77, 46, 145, 0.75);
+  --hero-cta-bg: linear-gradient(to bottom, #ce00ff, #a700cf);
+  --hero-cta-fg: #ffffff;
+  --hero-cta-border: none;
+  --hero-cloud-display: none;
+
+  /* Signature 3D primary button — gradient + inset highlight + outer drop */
+  --btn-primary-bg: linear-gradient(to bottom, #ce00ff, #a700cf);
+  --btn-primary-bg-hover: linear-gradient(to bottom, #ce00ff, #a700cf);
+  --btn-primary-fg: #ffffff;
+  --btn-radius: 12px;
+  --btn-primary-shadow:
+    inset 0 1px 1px rgba(255, 255, 255, 0.45),
+    inset 0 -1px 2px rgba(130, 0, 160, 0.4),
+    0 2px 4px rgba(167, 0, 207, 0.3);
+  --btn-primary-shadow-hover:
+    inset 0 1px 1px rgba(255, 255, 255, 0.5),
+    inset 0 -1px 2px rgba(130, 0, 160, 0.35),
+    0 3px 10px rgba(255, 56, 235, 0.25);
+  --btn-primary-shadow-active:
+    inset 0 1px 1px rgba(255, 255, 255, 0.25),
+    inset 0 -1px 1px rgba(130, 0, 160, 0.2),
+    0 1px 2px rgba(206, 0, 255, 0.2);
+  --btn-primary-translate-hover: -1px;
+  --btn-primary-translate-active: 1px;
+
+  /* Pills: keep round but stronger borders */
+  --pill-radius: 999px;
+
+  /* Badges */
+  --badge-tag-bg: rgba(255, 56, 235, 0.18);
+  --badge-tag-fg: #a80098;
+  --badge-online-bg: rgba(67, 96, 247, 0.18);
+  --badge-online-fg: #2d3fb0;
+  --badge-location-bg: rgba(167, 255, 144, 0.3);
+  --badge-location-fg: #2d7a1a;
+}
+
+/* --- Body: lavender → blush gradient + faint white grid overlay --- */
+:root[data-theme="fujocoded"] body {
+  background: linear-gradient(180deg, #9687fa 0%, #fbb8fe 100%);
+  background-attachment: fixed;
+  position: relative;
+  isolation: isolate;
+}
+
+:root[data-theme="fujocoded"] body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image:
+    linear-gradient(to right, white 1px, transparent 1px),
+    linear-gradient(to bottom, white 1px, transparent 1px);
+  background-size: 28px 28px;
+  opacity: 0.08;
+  pointer-events: none;
+  z-index: 0;
+}
+
+:root[data-theme="fujocoded"] body > *:not(.skip-link) {
+  position: relative;
+  z-index: 1;
+}
+
+/* --- Glass navbar --- */
+:root[data-theme="fujocoded"] .site-header {
+  backdrop-filter: blur(18px) saturate(70%) brightness(1.15);
+  -webkit-backdrop-filter: blur(18px) saturate(70%) brightness(1.15);
+  border-bottom: 1px solid rgba(77, 46, 145, 0.12);
+}
+
+/* The hero shouldn't sit edge-to-edge as a colored band — it's a card now */
+:root[data-theme="fujocoded"] .hero {
+  margin: var(--space-2xl) auto;
+  max-width: calc(var(--content-width) - 2 * var(--space-lg));
+  border-radius: 12px;
+  box-shadow:
+    0 10px 22px rgba(77, 46, 145, 0.16),
+    0 3px 8px rgba(42, 26, 76, 0.1);
+  backdrop-filter: blur(16px) saturate(130%);
+  -webkit-backdrop-filter: blur(16px) saturate(130%);
+}
+
+/* Selection: signature pink */
+:root[data-theme="fujocoded"] ::selection {
+  background: #ff38eb;
+  color: #ffffff;
+}
+
+/* Reduced motion: skip transform on buttons */
+@media (prefers-reduced-motion: reduce) {
+  :root[data-theme="fujocoded"] {
+    --btn-primary-translate-hover: 0;
+    --btn-primary-translate-active: 0;
+  }
+}

--- a/src/styles/themes/horizon.css
+++ b/src/styles/themes/horizon.css
@@ -1,0 +1,48 @@
+/* ============================================
+   Theme: horizon (default)
+   Mood: warm, breezy, people-forward — light mode
+
+   Applied on :root, so it's the default when no
+   [data-theme] attribute is set.
+
+   See tokens.base.css for the rules every theme follows.
+   ============================================ */
+
+:root {
+  /* --- Base tokens (required) --- */
+
+  /* Surface ramp + paired content */
+  --color-base-100: oklch(99% 0.004 250);
+  --color-base-200: oklch(93% 0.008 250);
+  --color-base-300: oklch(88% 0.008 250);
+  --color-base-content: oklch(22% 0.01 250);
+
+  /* Brand pairs */
+  --color-primary: oklch(48% 0.14 250);
+  --color-primary-content: oklch(98% 0.005 250);
+
+  --color-secondary: oklch(62% 0.11 250);
+  --color-secondary-content: oklch(98% 0.005 250);
+
+  --color-accent: oklch(55% 0.14 30);
+  --color-accent-content: oklch(98% 0.005 30);
+
+  --color-neutral: oklch(38% 0.01 250);
+  --color-neutral-content: oklch(97% 0.005 250);
+
+  /* Status pairs */
+  --color-info: oklch(58% 0.12 230);
+  --color-info-content: oklch(98% 0.005 230);
+
+  --color-success: oklch(50% 0.12 145);
+  --color-success-content: oklch(98% 0.005 145);
+
+  --color-warning: oklch(72% 0.15 80);
+  --color-warning-content: oklch(22% 0.05 80);
+
+  --color-error: oklch(55% 0.18 25);
+  --color-error-content: oklch(98% 0.005 25);
+
+  /* --- Component overrides (optional) ---
+     Horizon uses the semantic defaults; nothing to override. */
+}

--- a/src/styles/themes/ngerakines.css
+++ b/src/styles/themes/ngerakines.css
@@ -1,0 +1,146 @@
+/* ============================================
+   Theme: ngerakines
+   Mood: Y2K / GeoCities — ridge borders, Comic Sans,
+         flashing buttons, blinding primaries.
+         Ported from atmosphereconf.
+
+   Applied via <html data-theme="ngerakines">.
+
+   Note: this theme overrides --font-* tokens.
+   The structural-tokens-aren't-themed rule has a carve-out
+   for fonts: a theme's whole vibe often hinges on type.
+   Spacing, sizes, breakpoints, and motion durations
+   remain off-limits for themes.
+   ============================================ */
+
+:root[data-theme="ngerakines"] {
+  /* --- Base tokens --- */
+  /* Surface ramp: lavender page, butter-yellow card surface, ddd separator */
+  --color-base-100: #ccccff; /* page */
+  --color-base-200: #ddddee; /* muted */
+  --color-base-300: #800080; /* "border" base — purple */
+  --color-base-content: #000000;
+
+  /* Brand: red primary, butter secondary, magenta accent */
+  --color-primary: #cc0000;
+  --color-primary-content: #ffffff;
+
+  --color-secondary: #ffffcc;
+  --color-secondary-content: #000000;
+
+  --color-accent: #ff00ff;
+  --color-accent-content: #ffffff;
+
+  --color-neutral: #555555;
+  --color-neutral-content: #ffffff;
+
+  /* Status — flat web-safe primaries */
+  --color-info: #0000ff;
+  --color-info-content: #ffffff;
+
+  --color-success: #008800;
+  --color-success-content: #ffff00;
+
+  --color-warning: #ffcc00;
+  --color-warning-content: #000080;
+
+  --color-error: #ff0000;
+  --color-error-content: #ffff00;
+
+  /* --- Font overrides (vibe-defining) --- */
+  --font-display: "Comic Sans MS", "Comic Sans", "Chalkboard SE", cursive;
+  --font-body: "Comic Sans MS", "Comic Sans", "Chalkboard SE", cursive;
+
+  /* --- Pills & avatars go square in this theme --- */
+  --pill-radius: 0;
+  --avatar-radius: 0;
+
+  /* --- Card: square, ridge border, butter background --- */
+  --card: #ffffcc;
+  --card-radius: 0;
+  --card-border: #800080;
+  --card-border-width: 3px;
+  --card-border-style: ridge;
+  --card-border-hover: #ff00ff;
+  --card-shadow: none;
+
+  /* --- Button: square with outset bevel --- */
+  --btn-radius: 0;
+  --btn-primary-border-style: outset;
+  --btn-primary-border-width: 3px;
+  --btn-primary-border-color: #ff6666;
+  --btn-primary-text-transform: uppercase;
+  --btn-primary-animation: ngerakines-flash 1s infinite;
+
+  /* --- Header: navy bg, lime + yellow text, red border --- */
+  --header-bg: #000080;
+  --header-fg: #00ff00;
+  --header-fg-muted: #ffff00;
+  --header-border: #ff0000;
+  --header-link: #ffff00;
+  --header-link-hover-bg: rgba(255, 255, 0, 0.15);
+  --header-link-inactive: #00ff00;
+
+  /* --- Footer: bright yellow, purple text --- */
+  --footer-bg: #ffff00;
+  --footer-border: #800080;
+  --footer-fg-muted: #800080;
+
+  /* --- Hero: black bg, neon green text, red dashed border --- */
+  --hero-bg: #000000;
+  --hero-fg: #00ff00;
+  --hero-fg-muted: #ffff00;
+  --hero-title: #ff0000;
+  --hero-title-shadow: 3px 3px 0 #ffff00;
+  --hero-title-style: italic;
+  --hero-subtitle: #00cccc;
+  --hero-border-style: dashed;
+  --hero-border-width: 5px;
+  --hero-border-color: #ff0000;
+  --hero-cloud-display: none;
+  --hero-cta-bg: #cc0000;
+  --hero-cta-fg: #ffff00;
+  --hero-cta-border: 3px outset #ff6666;
+  --hero-cta-animation: ngerakines-flash 1s infinite;
+
+  /* --- Badges: flat ngerakines colors --- */
+  --badge-tag-bg: #ccccff;
+  --badge-tag-fg: #000080;
+  --badge-online-bg: #ccffff;
+  --badge-online-fg: #006666;
+  --badge-location-bg: #ccffcc;
+  --badge-location-fg: #006600;
+
+  /* Ghost button on red bg looks unhinged — keep readable */
+  --btn-ghost-border: #ffff00;
+  --btn-ghost-bg-hover: rgba(255, 255, 0, 0.15);
+  --btn-ghost-border-hover: #ffffff;
+}
+
+/* Flashing button — drives both --btn-primary and --hero-cta */
+@keyframes ngerakines-flash {
+  0%,
+  100% {
+    background: #cc0000;
+    color: #ffff00;
+  }
+  50% {
+    background: #ffff00;
+    color: #cc0000;
+  }
+}
+
+/* The site uses card hover by changing border-color only;
+   in ridge-border land that looks broken — bump width on hover. */
+:root[data-theme="ngerakines"] .post-card:hover,
+:root[data-theme="ngerakines"] .event-card:hover {
+  border-color: #ff00ff;
+}
+
+/* Respect reduced-motion: kill the flash */
+@media (prefers-reduced-motion: reduce) {
+  :root[data-theme="ngerakines"] {
+    --btn-primary-animation: none;
+    --hero-cta-animation: none;
+  }
+}

--- a/src/styles/tokens.base.css
+++ b/src/styles/tokens.base.css
@@ -1,0 +1,41 @@
+/* ============================================
+   Base tokens — the layer themes redefine.
+
+   Each theme lives in its own file under ./themes/.
+   The default theme applies to :root; named themes
+   apply via :root[data-theme="..."] on <html>
+   (the :root prefix bumps specificity so theme overrides
+   beat the :root defaults in tokens.semantic.css and
+   tokens.components.css).
+
+   Rules every theme MUST follow:
+   - Redefine every base token listed below.
+   - Use plain colors only (hex / rgb / oklch).
+     No color-mix(), no var() chains in this layer —
+     keeps it serializable for the future
+     community.atmosphere.theme lexicon.
+   - May also override component tokens
+     (see tokens.components.css) for theme-specific patterns
+     like a header surface that diverges from the page bg.
+   - MUST NOT override the semantic layer.
+
+   Required base tokens:
+     Surfaces:    --color-base-100, --color-base-200,
+                  --color-base-300, --color-base-content
+     Brand:       --color-primary,   --color-primary-content
+                  --color-secondary, --color-secondary-content
+                  --color-accent,    --color-accent-content
+                  --color-neutral,   --color-neutral-content
+     Status:      --color-info / --color-info-content
+                  --color-success / --color-success-content
+                  --color-warning / --color-warning-content
+                  --color-error / --color-error-content
+
+   Components MUST NOT consume base tokens directly —
+   use the semantic or component layer.
+   ============================================ */
+
+@import "./themes/horizon.css";
+@import "./themes/blacksky.css";
+@import "./themes/ngerakines.css";
+@import "./themes/fujocoded.css";

--- a/src/styles/tokens.components.css
+++ b/src/styles/tokens.components.css
@@ -1,0 +1,107 @@
+/* ============================================
+   Component / pattern tokens — scoped knobs.
+   Composed from semantic tokens. Add only when a
+   component diverges from a semantic default.
+   ============================================ */
+
+:root {
+  /* Badges */
+  --badge-tag-bg: var(--primary-muted);
+  --badge-tag-fg: var(--primary-muted-foreground);
+
+  --badge-online-bg: var(--primary-muted);
+  --badge-online-fg: var(--primary-muted-foreground);
+
+  --badge-location-bg: var(--success-muted);
+  --badge-location-fg: var(--success-muted-foreground);
+
+  /* Buttons */
+  --btn-primary-bg: var(--primary);
+  --btn-primary-fg: var(--primary-foreground);
+  --btn-primary-bg-hover: var(--primary-hover);
+
+  --btn-ghost-bg-hover: var(--primary-muted);
+  --btn-ghost-border: var(--border);
+  --btn-ghost-border-hover: color-mix(
+    in oklch,
+    var(--primary) 25%,
+    var(--background)
+  );
+
+  /* Card */
+  --card-border: var(--border);
+  --card-border-hover: color-mix(
+    in oklch,
+    var(--primary) 35%,
+    var(--background)
+  );
+
+  /* Header */
+  --header-bg: var(--card);
+  --header-border: var(--border);
+  --header-fg: var(--foreground);
+  --header-fg-muted: var(--foreground-muted);
+  --header-link: var(--primary);
+  --header-link-hover-bg: color-mix(
+    in oklch,
+    var(--primary) 25%,
+    var(--background)
+  );
+  --header-link-inactive: color-mix(
+    in oklch,
+    var(--primary) 50%,
+    var(--background)
+  );
+
+  /* Footer */
+  --footer-bg: var(--muted);
+  --footer-border: var(--border);
+  --footer-fg-muted: var(--foreground-muted);
+
+  /* Subtle separator (e.g. dot between meta items) */
+  --separator-fg: var(--foreground-subtle);
+
+  /* Card shape (themes can swap radius/border style for retro looks) */
+  --card-radius: var(--radius-md);
+  --card-border-style: solid;
+  --card-border-width: 1px;
+  --card-shadow: none;
+
+  /* Pill shape — community pills, badges, the theme toggle.
+     Themes can square these (e.g. ngerakines) by setting it to 0. */
+  --pill-radius: var(--radius-pill);
+  --avatar-radius: 50%;
+
+  /* Button shape & motion (themes can override) */
+  --btn-radius: var(--radius-sm);
+  --btn-primary-border-style: none;
+  --btn-primary-border-width: 0;
+  --btn-primary-border-color: transparent;
+  --btn-primary-text-transform: none;
+  --btn-primary-animation: none;
+  --btn-primary-shadow: none;
+  --btn-primary-shadow-hover: none;
+  --btn-primary-shadow-active: none;
+  --btn-primary-translate-hover: 0;
+  --btn-primary-translate-active: 0;
+
+  /* Hero — defaults to brand primary surface */
+  --hero-bg: var(--primary);
+  --hero-fg: var(--primary-foreground);
+  --hero-fg-muted: color-mix(in oklch, var(--primary-foreground) 75%, transparent);
+  --hero-title: var(--primary-foreground);
+  --hero-title-shadow: none;
+  --hero-title-style: normal;
+  --hero-subtitle: var(--hero-fg-muted);
+  --hero-border-style: none;
+  --hero-border-width: 0;
+  --hero-border-color: transparent;
+  --hero-cta-bg: var(--primary-foreground);
+  --hero-cta-fg: var(--primary);
+  --hero-cta-border: none;
+  --hero-cta-animation: none;
+  --hero-cloud-display: block;
+}
+
+/* Theme-specific component overrides live alongside the
+   theme definition in src/styles/themes/<theme>.css. */

--- a/src/styles/tokens.semantic.css
+++ b/src/styles/tokens.semantic.css
@@ -1,0 +1,132 @@
+/* ============================================
+   Semantic tokens — theme-agnostic.
+   Composed only from base tokens.
+
+   Rules:
+   - Components consume these by default.
+   - Themes do NOT override this layer.
+   - color-mix() is allowed; raw colors are not.
+   ============================================ */
+
+:root {
+  /* Surfaces */
+  --background: var(--color-base-100);
+  --foreground: var(--color-base-content);
+
+  --card: var(--color-base-100);
+  --card-foreground: var(--color-base-content);
+
+  --popover: var(--color-base-100);
+  --popover-foreground: var(--color-base-content);
+
+  --muted: var(--color-base-200);
+  --muted-foreground: color-mix(
+    in oklch,
+    var(--color-base-content) 65%,
+    var(--color-base-100)
+  );
+
+  /* Foreground variants (layered emphasis) */
+  --foreground-secondary: color-mix(
+    in oklch,
+    var(--color-base-content) 70%,
+    var(--color-base-100)
+  );
+  --foreground-muted: color-mix(
+    in oklch,
+    var(--color-base-content) 55%,
+    var(--color-base-100)
+  );
+  --foreground-subtle: color-mix(
+    in oklch,
+    var(--color-base-content) 30%,
+    var(--color-base-100)
+  );
+
+  /* Borders / interactive */
+  --border: var(--color-base-300);
+  --input: var(--color-base-300);
+  --ring: var(--color-primary);
+
+  /* Brand */
+  --primary: var(--color-primary);
+  --primary-foreground: var(--color-primary-content);
+  --primary-hover: color-mix(
+    in oklch,
+    var(--color-primary) 80%,
+    var(--color-base-content)
+  );
+  --primary-muted: color-mix(
+    in oklch,
+    var(--color-primary) 10%,
+    var(--color-base-100)
+  );
+  --primary-muted-foreground: var(--color-primary);
+
+  --secondary: var(--color-secondary);
+  --secondary-foreground: var(--color-secondary-content);
+
+  --accent: var(--color-accent);
+  --accent-foreground: var(--color-accent-content);
+
+  /* Links */
+  --link: var(--color-primary);
+  --link-hover: color-mix(
+    in oklch,
+    var(--color-primary) 80%,
+    var(--color-base-content)
+  );
+
+  /* Status — solid + muted (muted still signals the state) */
+  --info: var(--color-info);
+  --info-foreground: var(--color-info-content);
+  --info-muted: color-mix(
+    in oklch,
+    var(--color-info) 12%,
+    var(--color-base-100)
+  );
+  --info-muted-foreground: color-mix(
+    in oklch,
+    var(--color-info) 75%,
+    var(--color-base-content)
+  );
+
+  --success: var(--color-success);
+  --success-foreground: var(--color-success-content);
+  --success-muted: color-mix(
+    in oklch,
+    var(--color-success) 14%,
+    var(--color-base-100)
+  );
+  --success-muted-foreground: color-mix(
+    in oklch,
+    var(--color-success) 70%,
+    var(--color-base-content)
+  );
+
+  --warning: var(--color-warning);
+  --warning-foreground: var(--color-warning-content);
+  --warning-muted: color-mix(
+    in oklch,
+    var(--color-warning) 18%,
+    var(--color-base-100)
+  );
+  --warning-muted-foreground: color-mix(
+    in oklch,
+    var(--color-warning) 65%,
+    var(--color-base-content)
+  );
+
+  --error: var(--color-error);
+  --error-foreground: var(--color-error-content);
+  --error-muted: color-mix(
+    in oklch,
+    var(--color-error) 12%,
+    var(--color-base-100)
+  );
+  --error-muted-foreground: color-mix(
+    in oklch,
+    var(--color-error) 70%,
+    var(--color-base-content)
+  );
+}


### PR DESCRIPTION
## overview

related to issue: #9 [support themes](https://github.com/ATProtocol-Community/atproto-community/issues/9)

this PR adds the harness for themes along with 4 themes (default, dark mode, and 2 outliers) to try to get as many touch points down as possible in first pass.

>[!IMPORTANT]
> i will break this down into 4/5 PRs. this got too big for review. this will just serve as refrence of all the pieces together. 

## screengrabs


https://github.com/user-attachments/assets/d7ddda73-edc3-4aaf-b6d5-ff1dae8011f7

https://github.com/user-attachments/assets/644de7c0-438e-42c9-ab9d-1131bd66eddb


