### PR TITLE
fix(page) incorrect Add community url

### DIFF
--- a/src/pages/communities.astro
+++ b/src/pages/communities.astro
@@ -32,7 +32,7 @@ const regions = [...grouped.keys()].sort(
       <h1>Communities</h1>
       <p class="communities-sub">
         AT Protocol communities around the world. Each group is run independently by local organizers.
-        Find one near you or <a href="https://bsky.app/profile/ngerakines.me" rel="noopener noreferrer" target="_blank">start your own</a>.
+        Find one near you or <a href="https://github.com/ATProtocol-Community/atmosphere-community/issues/new?template=add-community.yml" rel="noopener noreferrer" target="_blank">start your own</a>.
       </p>
 
       {regions.map((region) => (


### PR DESCRIPTION
Fixes https://github.com/ATProtocol-Community/atmosphere-community/issues/8

"Start your own" CTA URl was pointing to Nick Gerakines's bluesky profile. This points it to this repository new Issue/add-community issue template.